### PR TITLE
Ticket 6: View comments with article

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -151,3 +151,18 @@
   /* border: 2px solid firebrick; */
 }
 
+.CommentsList {
+  opacity: 90%;
+  margin-top: 2em;
+  border-top: 1px solid darkgray;  
+}
+
+.CommentCard {
+  border-bottom: 1px solid darkgray; 
+  margin-bottom: 1em; 
+}
+
+.CommentCard:last-child {
+  border-bottom: none;
+}
+

--- a/src/components/ArticleDisplay.jsx
+++ b/src/components/ArticleDisplay.jsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { fetchArticleById } from "../utils/api";
 import UserDetails from "./UserDetails";
 import Byline from "./Byline";
+import CommentsList from "./CommentsList";
 
 const ArticleDisplay = () => {
     const { article_id } = useParams();
@@ -32,6 +33,9 @@ const ArticleDisplay = () => {
                     <p>{articleData.body}</p>
                 </div>
             </article>
+            <section>
+                <CommentsList></CommentsList>
+            </section>
         </>
     );
 };

--- a/src/components/Byline.jsx
+++ b/src/components/Byline.jsx
@@ -8,11 +8,13 @@ const Byline = ({ username, date, topic }) => {
                     <UserDetails username={username} />
                     <p>{new Date(date).toLocaleDateString()}</p>
                 </div>
-                <div className="Byline-right">
-                    <div className="Byline__topic">
-                        <p>{topic}</p>
+                {topic && (
+                    <div className="Byline-right">
+                        <div className="Byline__topic">
+                            <p>{topic}</p>
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
         </>
     );

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -1,0 +1,15 @@
+import Byline from "./Byline";
+
+const CommentCard = ({ comment }) => {
+    return (
+        <>
+            <Byline
+                username={comment.author}
+                date={comment.created_at}
+            ></Byline>
+            <p>{comment.body}</p>
+        </>
+    );
+};
+
+export default CommentCard;

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -3,11 +3,15 @@ import Byline from "./Byline";
 const CommentCard = ({ comment }) => {
     return (
         <>
-            <Byline
-                username={comment.author}
-                date={comment.created_at}
-            ></Byline>
-            <p>{comment.body}</p>
+            <section className="CommentCard">
+                <Byline
+                    username={comment.author}
+                    date={comment.created_at}
+                ></Byline>
+                <div className="CommentCard__body">
+                    <p>{comment.body}</p>
+                </div>
+            </section>
         </>
     );
 };

--- a/src/components/CommentsList.jsx
+++ b/src/components/CommentsList.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { fetchCommentsByArticleId } from "../utils/api";
+import { useParams } from "react-router-dom";
+import CommentCard from "./CommentCard";
+
+const CommentsList = () => {
+    const { article_id } = useParams();
+    const [commentsData, setCommentsData] = useState([]);
+
+    useEffect(() => {
+        fetchCommentsByArticleId(article_id).then(({ data: { comments } }) =>
+            setCommentsData(comments)
+        );
+    });
+
+    return (
+        <>
+            <h3>Comments</h3>
+            {commentsData.map((comment) => {
+                return <CommentCard comment={comment} />;
+            })}
+        </>
+    );
+};
+
+export default CommentsList;

--- a/src/components/CommentsList.jsx
+++ b/src/components/CommentsList.jsx
@@ -15,10 +15,17 @@ const CommentsList = () => {
 
     return (
         <>
-            <h3>Comments</h3>
-            {commentsData.map((comment) => {
-                return <CommentCard comment={comment} />;
-            })}
+            <section className="CommentsList">
+                <h3>Comments</h3>
+                {commentsData.map((comment) => {
+                    return (
+                        <CommentCard
+                            comment={comment}
+                            key={`c_${comment.comment_id}`}
+                        />
+                    );
+                })}
+            </section>
         </>
     );
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -15,3 +15,7 @@ export const fetchArticleById = (article_id) => {
 export const fetchUserByUsername = (username) => {
     return newsApi.get(`/users/${username}`)
 }
+
+export const fetchCommentsByArticleId = (article_id) => {
+    return newsApi.get(`/articles/${article_id}/comments`)
+}


### PR DESCRIPTION
# Comments now displayed under articles on /article/:article_id routes

##  Setup
- Adds CommentsList and CommentCard components
- Adds fetchCommentsbyArticleId to api.js in utils

## CommentsList
- Fetches comments for the article by article_id (coming from params)
- Maps over the comments, returning a CommentCard for each, passing down the comment

## CommentCard
- Uses Byline component to display avatar and author name, from comment object in props
- Returns the body of the comment

## Styling
- Just added  a horizontal line under each card for some visual separation for now

## Notes
- Made the right side of Byline conditional as it was rendering the colour of the empty topic part
