### PR TITLE
Ticket 9: Delete comments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -183,7 +183,6 @@
   cursor: not-allowed;
 }
 
-
 .CommentCard {
   border-bottom: 1px solid darkgray; 
   margin-bottom: 1em; 
@@ -191,6 +190,11 @@
 
 .CommentCard:last-child {
   border-bottom: none;
+}
+
+.CommentCard__bottomLine{
+  display:flex;
+  justify-content: space-between;
 }
 
 .Votes {

--- a/src/App.css
+++ b/src/App.css
@@ -178,7 +178,7 @@
   padding: .5em;
 }
 
-.CommentForm button:disabled {
+.CommentForm button:disabled, .CommentCard__buttonsBox button:disabled {
   opacity:50%;
   cursor: not-allowed;
 }
@@ -195,6 +195,15 @@
 .CommentCard__bottomLine{
   display:flex;
   justify-content: space-between;
+  align-items: center;
+}
+
+
+
+.CommentCard__buttonsBox button {
+  background-color: darkmagenta;
+  color: white;
+  padding: .5em;
 }
 
 .Votes {

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -1,7 +1,11 @@
+import { useContext } from "react";
 import Byline from "./Byline";
 import Votes from "./Votes";
+import { UserContext } from "../contexts/User";
 
 const CommentCard = ({ comment }) => {
+    const { user } = useContext(UserContext);
+
     return (
         <>
             <section className="CommentCard">
@@ -12,11 +16,14 @@ const CommentCard = ({ comment }) => {
                 <div className="CommentCard__body">
                     <p>{comment.body}</p>
                 </div>
-                <Votes
-                    id={comment.comment_id}
-                    votes={comment.votes}
-                    voteType={"comment"}
-                ></Votes>
+                <div className="CommentCard__bottomLine">
+                    <Votes
+                        id={comment.comment_id}
+                        votes={comment.votes}
+                        voteType={"comment"}
+                    ></Votes>
+                    {user === comment.author && <button>Delete</button>}
+                </div>
             </section>
         </>
     );

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -2,9 +2,16 @@ import { useContext } from "react";
 import Byline from "./Byline";
 import Votes from "./Votes";
 import { UserContext } from "../contexts/User";
+import { deleteCommentByCommentId } from "../utils/api";
 
-const CommentCard = ({ comment }) => {
+const CommentCard = ({ comment, setCommentDeleted }) => {
     const { user } = useContext(UserContext);
+
+    const handleDelete = () => {
+        deleteCommentByCommentId(comment.comment_id).then(() => {
+            setCommentDeleted(comment.comment_id);
+        });
+    };
 
     return (
         <>
@@ -22,7 +29,15 @@ const CommentCard = ({ comment }) => {
                         votes={comment.votes}
                         voteType={"comment"}
                     ></Votes>
-                    {user === comment.author && <button>Delete</button>}
+                    {user === comment.author && (
+                        <button
+                            onClick={() => {
+                                handleDelete();
+                            }}
+                        >
+                            Delete
+                        </button>
+                    )}
                 </div>
             </section>
         </>

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -7,12 +7,19 @@ import { deleteCommentByCommentId } from "../utils/api";
 const CommentCard = ({ comment, setCommentDeleted }) => {
     const { user } = useContext(UserContext);
     const [isDeleteClicked, setIsDeleteClicked] = useState(false);
+    const [isDeleteError, setIsDeleteError] = useState(false);
 
     const handleDelete = () => {
         setIsDeleteClicked(true);
-        deleteCommentByCommentId(comment.comment_id).then(() => {
-            setCommentDeleted(comment.comment_id);
-        });
+        deleteCommentByCommentId(comment.comment_id)
+            .then(() => {
+                setCommentDeleted(comment.comment_id);
+                setIsDeleteError(false);
+            })
+            .catch((err) => {
+                setIsDeleteError(true);
+                setIsDeleteClicked(false);
+            });
     };
 
     return (
@@ -42,6 +49,9 @@ const CommentCard = ({ comment, setCommentDeleted }) => {
                         </button>
                     )}
                 </div>
+                {isDeleteError && (
+                    <p>Problem deleting comment, please try again later</p>
+                )}
             </section>
         </>
     );

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import Byline from "./Byline";
 import Votes from "./Votes";
 import { UserContext } from "../contexts/User";
@@ -6,8 +6,10 @@ import { deleteCommentByCommentId } from "../utils/api";
 
 const CommentCard = ({ comment, setCommentDeleted }) => {
     const { user } = useContext(UserContext);
+    const [isDeleteClicked, setIsDeleteClicked] = useState(false);
 
     const handleDelete = () => {
+        setIsDeleteClicked(true);
         deleteCommentByCommentId(comment.comment_id).then(() => {
             setCommentDeleted(comment.comment_id);
         });
@@ -34,8 +36,9 @@ const CommentCard = ({ comment, setCommentDeleted }) => {
                             onClick={() => {
                                 handleDelete();
                             }}
+                            disabled={isDeleteClicked}
                         >
-                            Delete
+                            {isDeleteClicked ? `Deleting...` : `Delete`}
                         </button>
                     )}
                 </div>

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -38,16 +38,18 @@ const CommentCard = ({ comment, setCommentDeleted }) => {
                         votes={comment.votes}
                         voteType={"comment"}
                     ></Votes>
-                    {user === comment.author && (
-                        <button
-                            onClick={() => {
-                                handleDelete();
-                            }}
-                            disabled={isDeleteClicked}
-                        >
-                            {isDeleteClicked ? `Deleting...` : `Delete`}
-                        </button>
-                    )}
+                    <div className="CommentCard__buttonsBox">
+                        {user === comment.author && (
+                            <button
+                                onClick={() => {
+                                    handleDelete();
+                                }}
+                                disabled={isDeleteClicked}
+                            >
+                                {isDeleteClicked ? `Deleting...` : `Delete`}
+                            </button>
+                        )}
+                    </div>
                 </div>
                 {isDeleteError && (
                     <p>Problem deleting comment, please try again later</p>

--- a/src/components/CommentsList.jsx
+++ b/src/components/CommentsList.jsx
@@ -10,13 +10,14 @@ const CommentsList = () => {
     const [loading, setLoading] = useState(true);
     const [commentExpanded, setCommentExpanded] = useState(false);
     const [commentPosted, setCommentPosted] = useState(null);
+    const [commentDeleted, setCommentDeleted] = useState(null);
 
     useEffect(() => {
         fetchCommentsByArticleId(article_id).then(({ data: { comments } }) => {
             setCommentsData(comments);
             setLoading(false);
         });
-    }, [commentPosted]);
+    }, [commentPosted, commentDeleted]);
 
     if (loading) return <h2>Loading comments...</h2>;
 
@@ -69,6 +70,7 @@ const CommentsList = () => {
                         <CommentCard
                             comment={comment}
                             key={`c_${comment.comment_id}`}
+                            setCommentDeleted={setCommentDeleted}
                         />
                     );
                 })}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -31,3 +31,7 @@ export const patchVotesByCommentId = (comment_id, inc) => {
 export const postCommentByArticleId = (article_id, req) => {
     return newsApi.post(`/articles/${article_id}/comments`, req)
 }
+
+export const deleteCommentByCommentId = (comment_id) => {
+    return newsApi.delete(`/comments/${comment_id}`)
+}


### PR DESCRIPTION
# User can now delete own comments

## Overview

Delete button now visible alongside any comments created by logged-in user (currently hardcoded). Button triggers a DELETE request to the backend then re-renders the comment list on successful deletion. The button becomes disabled after clicking to prevent multiple requests. An error message is displayed in the instance of an error in the delete request.

## Set up / config
- Adds UserContext to CommentCard to access logged in user username
- Adds **`commentDeleted`** state to CommentsList and adds to dependency array for re-rendering of comments after deletion

## CommentCard
### Functionality
- Now renders delete button against any comment that has author that matches logged in user username from context
- Sends a `DELETE` request to the relative endpoint through  Axios in utils/api.js
- Comments get re-rendered  after successful deletion
- Delete button is immediately disabled after clicking to prevent multiple submissions
- Error message displays conditionally in case of error, delete button becomes re-enabled

### State Management
- **`isDeleteClicked`** - to control disabling of delete button, and to change text of button while processing
- **`isDeleteError`** - to control conditional rendering of error message in case of error from Delete request
- **`setCommentDeleted`** - from props - to cause parent CommentList to  re-render after succesful deletion

## Notes
- Will consider implementing a confirmation step before deletion in the future to prevent accidental deletion
