### PR TITLE
Ticket 10: Separate page for each topic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,12 +49,12 @@
 
 }
 
-.ArticleCard a, .ArticleCard a:visited, .ArticleCard a:active, .Header a, .Header a:visited, .Header a:active  {
+a, a:visited, a:active {
   color: inherit;
   text-decoration: none; 
 }
 
-.ArticleCard a:hover, .Header a:hover {
+a:hover {
   opacity: 80%;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -6,11 +6,21 @@
   text-align: left;
 }
 
-/* .HeaderWrapper {
+.TopicBar {
   display:flex;
+  flex-direction: row-reverse;
   align-items: center;
   justify-content: space-between;
-} */
+}
+
+.TopicBar__topicHeader h2 {
+  padding:0;
+  margin:0;
+}
+
+.TopicBar__topicHeader p {
+  margin:0;
+}
 
 .TopicSelector {
   border: 1px solid darkgray;
@@ -20,7 +30,6 @@
 .TopicSelector button {
  border-radius: 2px;
 }
-
 
 .TopicSelector__dropdown {
   text-align: right;

--- a/src/App.css
+++ b/src/App.css
@@ -114,7 +114,7 @@
   padding: .5em;
 }
 
-.Byline__topic p{
+.Byline__topic a{
   background-color: mediumaquamarine; 
   border-radius: 2px; 
   padding: .25em .5em;

--- a/src/App.css
+++ b/src/App.css
@@ -6,11 +6,11 @@
   text-align: left;
 }
 
-.HeaderWrapper {
+/* .HeaderWrapper {
   display:flex;
   align-items: center;
   justify-content: space-between;
-}
+} */
 
 .TopicSelector {
   border: 1px solid darkgray;

--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,32 @@
   text-align: left;
 }
 
+.HeaderWrapper {
+  display:flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.TopicSelector {
+  border: 1px solid darkgray;
+  border-radius: 2px;
+  position: relative;
+}
+.TopicSelector button {
+ border-radius: 2px;
+}
+
+
+.TopicSelector__dropdown {
+  text-align: right;
+  padding-right: 1em;
+  position: absolute;
+  top: 100%;
+  width: 80%;
+  background-color: white;
+  color: #242424;
+}
+
 .ArticlesList {
   /* border: 2px solid royalblue; */
   padding: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,15 +4,12 @@ import ArticlesList from "./components/ArticlesList";
 import Header from "./components/Header";
 import ArticleDisplay from "./components/ArticleDisplay";
 import { UserProvider } from "./contexts/User";
-import TopicSelector from "./components/TopicSelector";
+import TopicBar from "./components/TopicBar";
 
 const App = () => {
     return (
         <UserProvider>
-            <div className="HeaderWrapper">
-                <Header />
-                <TopicSelector />
-            </div>
+            <Header />
             <Routes>
                 <Route path="/" element={<ArticlesList />}></Route>
                 <Route path="/articles" element={<ArticlesList />}></Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,13 @@ import ArticlesList from "./components/ArticlesList";
 import Header from "./components/Header";
 import ArticleDisplay from "./components/ArticleDisplay";
 import { UserProvider } from "./contexts/User";
+import TopicSelector from "./components/TopicSelector";
 
 const App = () => {
     return (
         <UserProvider>
             <Header />
+            <TopicSelector />
             <Routes>
                 <Route path="/" element={<ArticlesList />}></Route>
                 <Route path="/articles" element={<ArticlesList />}></Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,10 @@ const App = () => {
                     path="/articles/:article_id"
                     element={<ArticleDisplay />}
                 ></Route>
+                <Route
+                    path="/topics/:topic_name"
+                    element={<ArticlesList />}
+                ></Route>
             </Routes>
         </UserProvider>
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,8 +9,10 @@ import TopicSelector from "./components/TopicSelector";
 const App = () => {
     return (
         <UserProvider>
-            <Header />
-            <TopicSelector />
+            <div className="HeaderWrapper">
+                <Header />
+                <TopicSelector />
+            </div>
             <Routes>
                 <Route path="/" element={<ArticlesList />}></Route>
                 <Route path="/articles" element={<ArticlesList />}></Route>

--- a/src/components/ArticleDisplay.jsx
+++ b/src/components/ArticleDisplay.jsx
@@ -5,6 +5,7 @@ import UserDetails from "./UserDetails";
 import Byline from "./Byline";
 import CommentsList from "./CommentsList";
 import Votes from "./Votes";
+import TopicBar from "./TopicBar";
 
 const ArticleDisplay = () => {
     const { article_id } = useParams();
@@ -22,6 +23,7 @@ const ArticleDisplay = () => {
 
     return (
         <>
+            <TopicBar topic_name={articleData.topic} />
             <article className="ArticleDisplay">
                 <Byline
                     username={articleData.author}

--- a/src/components/ArticleDisplay.jsx
+++ b/src/components/ArticleDisplay.jsx
@@ -10,20 +10,19 @@ import TopicBar from "./TopicBar";
 const ArticleDisplay = () => {
     const { article_id } = useParams();
     const [articleData, setArticleData] = useState({});
-    const [loading, setLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         fetchArticleById(article_id).then(({ data: { article } }) => {
             setArticleData(article);
-            setLoading(false);
+            setIsLoading(false);
         });
     }, [article_id]);
-
-    if (loading) return <h2>Loading article...</h2>;
 
     return (
         <>
             <TopicBar topic_name={articleData.topic} />
+            {isLoading && <h3>Loading article...</h3>}
             <article className="ArticleDisplay">
                 <Byline
                     username={articleData.author}

--- a/src/components/ArticlesList.jsx
+++ b/src/components/ArticlesList.jsx
@@ -2,12 +2,15 @@ import { useEffect } from "react";
 import ArticleCard from "./ArticleCard";
 import { fetchArticles } from "../utils/api";
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 
 const ArticlesList = () => {
     const [articlesData, setArticlesData] = useState([]);
     const [loading, setLoading] = useState(true);
+    const { topic_name } = useParams();
+
     useEffect(() => {
-        fetchArticles()
+        fetchArticles(topic_name)
             .then(({ data: { articles } }) => {
                 setArticlesData(articles);
                 setLoading(false);

--- a/src/components/ArticlesList.jsx
+++ b/src/components/ArticlesList.jsx
@@ -18,7 +18,7 @@ const ArticlesList = () => {
             .catch((err) => {
                 console.error(err.response.data);
             });
-    }, []);
+    }, [topic_name]);
 
     if (loading) return <h2>Loading articles...</h2>;
 

--- a/src/components/ArticlesList.jsx
+++ b/src/components/ArticlesList.jsx
@@ -3,6 +3,8 @@ import ArticleCard from "./ArticleCard";
 import { fetchArticles } from "../utils/api";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
+import TopicHeader from "./TopicBar";
+import TopicBar from "./TopicBar";
 
 const ArticlesList = () => {
     const [articlesData, setArticlesData] = useState([]);
@@ -24,9 +26,7 @@ const ArticlesList = () => {
 
     return (
         <>
-            {topic_name && (
-                <h2>{topic_name[0].toUpperCase() + topic_name.slice(1)}</h2>
-            )}
+            <TopicBar topic_name={topic_name} />
             <section className="ArticlesList">
                 {articlesData.map((article) => {
                     return (

--- a/src/components/ArticlesList.jsx
+++ b/src/components/ArticlesList.jsx
@@ -23,16 +23,21 @@ const ArticlesList = () => {
     if (loading) return <h2>Loading articles...</h2>;
 
     return (
-        <section className="ArticlesList">
-            {articlesData.map((article) => {
-                return (
-                    <ArticleCard
-                        key={article.article_id}
-                        article_id={article.article_id}
-                    />
-                );
-            })}
-        </section>
+        <>
+            {topic_name && (
+                <h2>{topic_name[0].toUpperCase() + topic_name.slice(1)}</h2>
+            )}
+            <section className="ArticlesList">
+                {articlesData.map((article) => {
+                    return (
+                        <ArticleCard
+                            key={article.article_id}
+                            article_id={article.article_id}
+                        />
+                    );
+                })}
+            </section>
+        </>
     );
 };
 

--- a/src/components/ArticlesList.jsx
+++ b/src/components/ArticlesList.jsx
@@ -8,25 +8,24 @@ import TopicBar from "./TopicBar";
 
 const ArticlesList = () => {
     const [articlesData, setArticlesData] = useState([]);
-    const [loading, setLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(true);
     const { topic_name } = useParams();
 
     useEffect(() => {
         fetchArticles(topic_name)
             .then(({ data: { articles } }) => {
                 setArticlesData(articles);
-                setLoading(false);
+                setIsLoading(false);
             })
             .catch((err) => {
                 console.error(err.response.data);
             });
     }, [topic_name]);
 
-    if (loading) return <h2>Loading articles...</h2>;
-
     return (
         <>
             <TopicBar topic_name={topic_name} />
+            {isLoading && <h3>Loading articles...</h3>}
             <section className="ArticlesList">
                 {articlesData.map((article) => {
                     return (

--- a/src/components/Byline.jsx
+++ b/src/components/Byline.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import UserDetails from "./UserDetails";
 
 const Byline = ({ username, date, topic }) => {
@@ -11,7 +12,9 @@ const Byline = ({ username, date, topic }) => {
                 {topic && (
                     <div className="Byline-right">
                         <div className="Byline__topic">
-                            <p>{topic}</p>
+                            <p>
+                                <Link to={`/topics/${topic}`}>{topic}</Link>
+                            </p>
                         </div>
                     </div>
                 )}

--- a/src/components/TopicBar.jsx
+++ b/src/components/TopicBar.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { fetchTopics } from "../utils/api";
+import TopicSelector from "./TopicSelector";
+
+const TopicBar = ({ topic_name }) => {
+    const [topicsData, setTopicsData] = useState([]);
+    const [topicDesc, setTopicDesc] = useState("");
+
+    useEffect(() => {
+        fetchTopics().then(({ data: topics }) => {
+            setTopicsData(topics);
+
+            const currentTopic = topics.topics.find(
+                (topic) => topic.slug === topic_name
+            );
+            if (currentTopic) {
+                setTopicDesc(currentTopic.description);
+            }
+        });
+    }, [topic_name]);
+
+    return (
+        <>
+            {topic_name && (
+                <>
+                    <h2>{topic_name[0].toUpperCase() + topic_name.slice(1)}</h2>
+                    <p>{topicDesc}</p>
+                </>
+            )}
+            {<TopicSelector topicsData={topicsData}></TopicSelector>}
+        </>
+    );
+};
+
+export default TopicBar;

--- a/src/components/TopicBar.jsx
+++ b/src/components/TopicBar.jsx
@@ -21,13 +21,20 @@ const TopicBar = ({ topic_name }) => {
 
     return (
         <>
-            {topic_name && (
-                <>
-                    <h2>{topic_name[0].toUpperCase() + topic_name.slice(1)}</h2>
-                    <p>{topicDesc}</p>
-                </>
-            )}
-            {<TopicSelector topicsData={topicsData}></TopicSelector>}
+            <section className="TopicBar">
+                {<TopicSelector topicsData={topicsData}></TopicSelector>}
+                <div className="TopicBar__topicHeader">
+                    {topic_name && (
+                        <>
+                            <h2>
+                                {topic_name[0].toUpperCase() +
+                                    topic_name.slice(1)}
+                            </h2>
+                            <p>{topicDesc}</p>
+                        </>
+                    )}
+                </div>
+            </section>
         </>
     );
 };

--- a/src/components/TopicSelector.jsx
+++ b/src/components/TopicSelector.jsx
@@ -1,18 +1,9 @@
 import { useEffect, useState } from "react";
-import { getTopics } from "../utils/api";
+import { fetchTopics } from "../utils/api";
 import { Link } from "react-router-dom";
 
-const TopicSelector = () => {
-    const [topicsData, setTopicsData] = useState([]);
+const TopicSelector = ({ topicsData }) => {
     const [isMenuVisible, setIsMenuVisible] = useState(false);
-    const [isLoading, setIsLoading] = useState(true);
-
-    useEffect(() => {
-        getTopics().then(({ data: { topics } }) => {
-            setTopicsData(topics);
-            setIsLoading(false);
-        });
-    }, []);
 
     const handleMenuToggle = () => {
         setIsMenuVisible(!isMenuVisible);
@@ -24,8 +15,7 @@ const TopicSelector = () => {
                 <button onClick={handleMenuToggle}>Topics</button>
                 {isMenuVisible && (
                     <div className="TopicSelector__dropdown">
-                        {isLoading && <p>Loading...</p>}
-                        {topicsData.map((topic, index) => {
+                        {topicsData.topics.map((topic, index) => {
                             return (
                                 <p key={index} onClick={handleMenuToggle}>
                                     <Link to={`/topics/${topic.slug}`}>

--- a/src/components/TopicSelector.jsx
+++ b/src/components/TopicSelector.jsx
@@ -5,10 +5,12 @@ import { Link } from "react-router-dom";
 const TopicSelector = () => {
     const [topicsData, setTopicsData] = useState([]);
     const [isMenuVisible, setIsMenuVisible] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         getTopics().then(({ data: { topics } }) => {
             setTopicsData(topics);
+            setIsLoading(false);
         });
     }, []);
 
@@ -22,6 +24,7 @@ const TopicSelector = () => {
                 <button onClick={handleMenuToggle}>Topics</button>
                 {isMenuVisible && (
                     <div className="TopicSelector__dropdown">
+                        {isLoading && <p>Loading...</p>}
                         {topicsData.map((topic, index) => {
                             return (
                                 <p key={index} onClick={handleMenuToggle}>

--- a/src/components/TopicSelector.jsx
+++ b/src/components/TopicSelector.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { getTopics } from "../utils/api";
+import { Link } from "react-router-dom";
+
+const TopicSelector = () => {
+    const [topicsData, setTopicsData] = useState([]);
+    const [isMenuVisible, setIsMenuVisible] = useState(false);
+
+    useEffect(() => {
+        getTopics().then(({ data: { topics } }) => {
+            setTopicsData(topics);
+        });
+    }, []);
+
+    const handleMenuToggle = () => {
+        setIsMenuVisible(!isMenuVisible);
+    };
+
+    return (
+        <>
+            <h2 onClick={handleMenuToggle}>Topics</h2>
+            {isMenuVisible && (
+                <>
+                    {topicsData.map((topic, index) => {
+                        return (
+                            <p key={index}>
+                                <Link to={`/topics/${topic.slug}`}>
+                                    {topic.slug}
+                                </Link>
+                            </p>
+                        );
+                    })}
+                </>
+            )}
+        </>
+    );
+};
+
+export default TopicSelector;

--- a/src/components/TopicSelector.jsx
+++ b/src/components/TopicSelector.jsx
@@ -18,20 +18,22 @@ const TopicSelector = () => {
 
     return (
         <>
-            <h2 onClick={handleMenuToggle}>Topics</h2>
-            {isMenuVisible && (
-                <>
-                    {topicsData.map((topic, index) => {
-                        return (
-                            <p key={index}>
-                                <Link to={`/topics/${topic.slug}`}>
-                                    {topic.slug}
-                                </Link>
-                            </p>
-                        );
-                    })}
-                </>
-            )}
+            <section className="TopicSelector">
+                <button onClick={handleMenuToggle}>Topics</button>
+                {isMenuVisible && (
+                    <div className="TopicSelector__dropdown">
+                        {topicsData.map((topic, index) => {
+                            return (
+                                <p key={index} onClick={handleMenuToggle}>
+                                    <Link to={`/topics/${topic.slug}`}>
+                                        {topic.slug}
+                                    </Link>
+                                </p>
+                            );
+                        })}
+                    </div>
+                )}
+            </section>
         </>
     );
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -39,3 +39,7 @@ export const postCommentByArticleId = (article_id, req) => {
 export const deleteCommentByCommentId = (comment_id) => {
     return newsApi.delete(`/comments/${comment_id}`)
 }
+
+export const getTopics = () => {
+    return newsApi.get(`/topics`)
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -40,6 +40,6 @@ export const deleteCommentByCommentId = (comment_id) => {
     return newsApi.delete(`/comments/${comment_id}`)
 }
 
-export const getTopics = () => {
+export const fetchTopics = () => {
     return newsApi.get(`/topics`)
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -4,8 +4,12 @@ const newsApi = axios.create({
     baseURL: "https://nc-news-dw.onrender.com/api"
 })
 
-export const fetchArticles = () => {
-    return newsApi.get(`/articles`)
+export const fetchArticles = (topic_name) => {
+    const params = {}
+    if(topic_name){
+        params.topic = topic_name
+    }
+    return newsApi.get(`/articles`, {params})
 }
 
 export const fetchArticleById = (article_id) => {


### PR DESCRIPTION
# Topic pages now available on /topics/:topic_name

# Overview

A page for each topic is now available, rendered using ArticlesList with an adjusted backend call to filter by topic. Tags on ArticleCard now link to the corresponding topic page, and a dropdown topic selector menu is now available. Each topic page also displays the topic slug and description in the TopicBar alongside the dropdown.

# Routing
- Adds routes for topic pages with parametric `topic_name` at `/topic/topic_name`, enabling dynamic rendering of topic-specific article cards

# ArticleCard
- The topic tag in the ArticleCard component is now a `Link` component, which directs to the respective topic page.   

# TopicBar
- Dynamically displays topic name and description if present. 

# TopicSelector
- Dropdown menu toggles open on click, and displays list of topics, each of which is a `Link` to the respective topic route 

# Notes
- The TopicBar is currently a child of both ArticlesList and ArticleDisplay. It re-renders when going from a list to a specific ArticleDisplay - a minor annoyance. Will consider lifting outside of routes so that it's always present (like a navbar) at a later time - will need to work out how to handle the topic_name state from ArticlesList and ArticleDisplay. 